### PR TITLE
Remove dangerous "chown" instructions

### DIFF
--- a/docs/installation/quick.md
+++ b/docs/installation/quick.md
@@ -23,7 +23,6 @@ $ sudo dpkg -i leofs_{VERSION}-1_ubuntu-16.04_amd64.deb
 $ ls -l /usr/local/leofs/
 total 4
 drwxr-xr-x 6 root   root   4096 Jan 20 00:00 {VERSION}
-$ chown -R leofs:leofs /usr/local/leofs/{VERSION}
 ```
 
 #### For Ubuntu 14.04
@@ -33,7 +32,6 @@ $ sudo dpkg -i leofs_{VERSION}-1_ubuntu-14.04_amd64.deb
 $ ls -l /usr/local/leofs/
 total 4
 drwxr-xr-x 6 root   root   4096 Jan 20 00:00 {VERSION}
-$ chown -R leofs:leofs /usr/local/leofs/{VERSION}
 ```
 
 ### CentOS
@@ -51,7 +49,6 @@ $ sudo rpm -ivh leofs-{VERSION}-1.el6.x86_64.rpm
 $ ls -l /usr/local/leofs/
 total 4
 drwxr-xr-x 6 root   root   4096 Jan 20 15:37 {VERSION}
-$ chown -R leofs:leofs /usr/local/leofs/{VERSION}
 ```
 
 #### For CentOS 7.x
@@ -62,7 +59,6 @@ $ sudo rpm -ivh leofs-{VERSION}-1.el7.x86_64.rpm
 $ ls -l /usr/local/leofs/
 total 4
 drwxr-xr-x 6 root   root   4096 Jan 20 15:37 {VERSION}
-$ chown -R leofs:leofs /usr/local/leofs/{VERSION}
 ```
 
 ## Configuration


### PR DESCRIPTION
"chown" command is not needed (and bad from security perspective, since it allows running code to change its own binaries on disk) for versions >= 1.3.3, it should be removed.